### PR TITLE
Component reg query functions

### DIFF
--- a/src/_enonicAdapter/ComponentRegistry.ts
+++ b/src/_enonicAdapter/ComponentRegistry.ts
@@ -38,18 +38,20 @@ interface ComponentDictionary {
 export type DataProcessor = (data: any, context?: Context) => Promise<Record<string, any>>;
 
 // TODO: also access as arguments: dataAsJson, pageAsJson, configAsJson from the first (meta) call here?
-//  To allow content or component config values to affect the query?
 //  Another option could be to let the component or page controller pass those values to nextjs by a header
 export type VariablesGetter = (path: string, context?: Context, config?: any) => VariablesGetterResult;
+
+export type QueryGetter = (config?: any) => string;
 
 export type VariablesGetterResult = {
     path: string,
     [variables: string]: any
 };
 
-export type SelectedQueryMaybeVariablesFunc = string |
-    { query: string, variables: VariablesGetter } |
-    [string, VariablesGetter];
+
+export type SelectedQueryMaybeVariablesFunc = string | QueryGetter |
+    { query: string | QueryGetter, variables: VariablesGetter } |
+    [string | QueryGetter, VariablesGetter];
 
 export const CATCH_ALL = "*";
 

--- a/src/_enonicAdapter/guillotine/fetchContent.ts
+++ b/src/_enonicAdapter/guillotine/fetchContent.ts
@@ -576,7 +576,7 @@ function getQueryAndVariables(type: string,
 
     let query, getVariables;
 
-    if (typeof selectedQuery === 'string') {
+    if (typeof selectedQuery === 'string' || typeof selectedQuery === 'function') {
         query = selectedQuery;
 
     } else if (Array.isArray(selectedQuery)) {
@@ -592,13 +592,17 @@ function getQueryAndVariables(type: string,
         throw Error(`getVariables for content type ${type} should be a function, not: ${typeof getVariables}`);
     }
 
-    if (query && typeof query !== 'string') {
-        throw Error(`Query for content type ${type} should be a string, not: ${typeof query}`);
+    if (query && typeof query !== 'string' && typeof query !== 'function') {
+        throw Error(`Query for content type ${type} should be a string or function, not: ${typeof query}`);
+    }
+
+    if (typeof query === 'function') {
+        query = query(config);
     }
 
     if (query) {
         return {
-            query: query,
+            query,
             variables: getVariables ? getVariables(path, context, config) : {path},
         };
     }


### PR DESCRIPTION
Added config param to the query function
Query can now be a function

This will allow us to register a function
`/_mappings.ts`
```
ComponentRegister.addX('', {
    query: MyQueryFunction
})
```

`/query/myComponent.ts`
```
export const MyQueryFunction = (config) => {
    const MyId = config.somevalue;
    
    let query = `
      get(key: $path) {
        guillotine {
          getChildren(${MyId}) {
            _id
          }
        }
      }
      `
}
```
